### PR TITLE
Navigate to backup flow

### DIFF
--- a/src/js/controllers/walletDetails.js
+++ b/src/js/controllers/walletDetails.js
@@ -168,7 +168,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
   };
 
   $scope.isFirstInGroup = function(index) {
-    if(index === 0) {
+    if (index === 0) {
       return true;
     }
     var curTx = $scope.txHistory[index];
@@ -177,7 +177,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
   };
 
   $scope.isLastInGroup = function(index) {
-    if(index === $scope.txHistory.length - 1) {
+    if (index === $scope.txHistory.length - 1) {
       return true;
     }
     return $scope.isFirstInGroup(index + 1);
@@ -234,15 +234,11 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
     });
   };
 
-  $scope.backup = function() {
-   //$state.go('tabs.preferences', {walletId: $scope.walletId});
-   //$state.transitionTo('tabs.preferences.backupWarning');
-  };
-
   var prevPos;
-  function getScrollPosition(){
+
+  function getScrollPosition() {
     var pos = $ionicScrollDelegate.getScrollPosition().top;
-    if(pos === prevPos) {
+    if (pos === prevPos) {
       $window.requestAnimationFrame(function() {
         getScrollPosition();
       });
@@ -250,29 +246,29 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
     }
     prevPos = pos;
     var amountHeight = 180 - pos;
-    if(amountHeight < 80) {
+    if (amountHeight < 80) {
       amountHeight = 80;
     }
     var contentMargin = amountHeight;
-    if(contentMargin > 180) {
+    if (contentMargin > 180) {
       contentMargin = 180;
     }
 
-    var amountScale = (amountHeight/180);
-    if(amountScale < 0.5) {
+    var amountScale = (amountHeight / 180);
+    if (amountScale < 0.5) {
       amountScale = 0.5;
     }
-    if(amountScale > 1.1) {
+    if (amountScale > 1.1) {
       amountScale = 1.1;
     }
 
     var s = amountScale;
 
-    $scope.altAmountOpacity = (amountHeight - 100)/80;
+    $scope.altAmountOpacity = (amountHeight - 100) / 80;
     $window.requestAnimationFrame(function() {
       $scope.amountHeight = amountHeight + 'px';
       $scope.contentMargin = contentMargin + 'px';
-      $scope.amountScale = 'scale3d(' + s + ',' + s + ',' + s+ ')';
+      $scope.amountScale = 'scale3d(' + s + ',' + s + ',' + s + ')';
       $scope.$digest();
       getScrollPosition();
     });
@@ -281,7 +277,7 @@ angular.module('copayApp.controllers').controller('walletDetailsController', fun
   var scrollWatcherInitialized;
 
   $scope.$on("$ionicView.enter", function(event, data) {
-    if(scrollWatcherInitialized || !$scope.amountIsCollapsible) {
+    if (scrollWatcherInitialized || !$scope.amountIsCollapsible) {
       return;
     }
     scrollWatcherInitialized = true;

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -151,7 +151,7 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
      */
 
     .state('tabs.wallet', {
-        url: '/wallet/{walletId}/{fromOnboarding}',
+        url: '/wallet/:walletId/:fromOnboarding',
         views: {
           'tab-home@tabs': {
             controller: 'walletDetailsController',
@@ -183,6 +183,14 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
           'tab-home@tabs': {
             controller: 'txDetailsController',
             templateUrl: 'views/tx-details.html'
+          }
+        }
+      })
+      .state('tabs.wallet.backupWarning', {
+        url: '/backupWarning/:from/:walletId',
+        views: {
+          'tab-home@tabs': {
+            templateUrl: 'views/backupWarning.html'
           }
         }
       })
@@ -601,7 +609,7 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
 
     /*
      *
-     * Back flow from receive
+     * Init backup flow
      *
      */
 

--- a/www/views/walletDetails.html
+++ b/www/views/walletDetails.html
@@ -139,7 +139,7 @@
       </div>
     </div> <!-- oh -->
 
-    <a class="wallet-not-backed-up-warning" ng-show="!isBackedUp" ng-click="backup()">
+    <a class="wallet-not-backed-up-warning" ng-show="!isBackedUp" ui-sref="tabs.wallet.backupWarning({from: 'tabs.wallet', walletId: walletId})">
       Wallet not backed up
     </a>
 


### PR DESCRIPTION
Only navigation is fixed here. There is an error in _getScrollPosition_ function, apparently is called multiple times:

<img width="419" alt="copay_-_copay_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/20308886/8979a4fa-ab24-11e6-80a3-1f97138bd6f0.png">


Note: adding log line to watch the multiple calls
```
....
var prevPos;

  function getScrollPosition() {
    console.log($ionicScrollDelegate.getScrollPosition());
    var pos = $ionicScrollDelegate.getScrollPosition().top;
    if (pos === prevPos) {
.....

```

<img width="458" alt="copay_-_copay_bitcoin_wallet" src="https://cloud.githubusercontent.com/assets/13851807/20308750/149cedae-ab24-11e6-9e1a-0942659856aa.png">
